### PR TITLE
Fix configuration

### DIFF
--- a/lib/rms_web_service.rb
+++ b/lib/rms_web_service.rb
@@ -7,14 +7,21 @@ RWS = RmsWebService
 module RmsWebService
   Endpoint = "https://api.rms.rakuten.co.jp/es/1.0/"
 
-  def configuration(&block)
-    @configuration ||= Configuration.new
-    block.call @configuration if block_given?
-    return @configuration
-  end
+  @@configuration = Configuration.new
 
+  def configure(&block)
+    block.call @@configuration if block_given?
+  end
+  module_function :configure
+
+  def configuration
+    @@configuration
+  end
   module_function :configuration
 
   class AuthError < StandardError
+  end
+
+  class ParameterError < StandardError
   end
 end

--- a/lib/rms_web_service/configuration.rb
+++ b/lib/rms_web_service/configuration.rb
@@ -4,12 +4,16 @@ module RmsWebService
   class Configuration
     attr_accessor :service_secret, :license_key
 
+    def initialize(args={})
+      @service_secret = args[:service_secret]
+      @license_key = args[:license_key]
+    end
+
     def encoded_keys
-      if service_secret.present? && license_key.present?
-        return "ESA " + Base64.encode64(service_secret + ":" + license_key).gsub(/\n/, "")
-      else
-        raise AuthError, 'please set serviceSecret and licenseKey'
-      end
+        raise RmsWebService::ParameterError, 'service_secret is required' unless service_secret.present?
+        raise RmsWebService::ParameterError, 'license_key is required' unless license_key.present?
+
+        "ESA " + Base64.encode64(service_secret + ":" + license_key).chomp
     end
   end
 end

--- a/spec/rms_web_service/configuration_spec.rb
+++ b/spec/rms_web_service/configuration_spec.rb
@@ -1,31 +1,44 @@
 require 'spec_helper'
-require 'rms_web_service/item'
 
-describe RmsWebService do
-  describe '.configuration' do
-    let(:config) {RmsWebService.configuration}
-  
-    context "don't set serviceSecret and licenseKey" do
-      it 'raise AuthError' do
-        expect{config.encoded_keys}.to raise_error RmsWebService::AuthError
+describe RmsWebService::Configuration do
+  let(:config){ described_class.new(service_secret: service_secret, license_key: license_key) }
+  let(:service_secret){ "dummy_service_secret" }
+  let(:license_key){ "dummy_license_key" }
+
+  describe "#service_secret" do
+    subject{ config.service_secret }
+    it { is_expected.to eq(service_secret) }
+  end
+
+  describe "#license_key" do
+    subject{ config.license_key }
+    it { is_expected.to eq(license_key) }
+  end
+
+  describe "#encoded_keys" do
+    context "with service_secret and license_key" do
+      let(:encoded_string){
+        encoded_credentials = Base64.encode64("#{service_secret}:#{license_key}")
+        "ESA #{encoded_credentials}".chomp
+      }
+
+      subject{ config.encoded_keys }
+      it { is_expected.to eq(encoded_string) }
+    end
+
+    context "without service_secret" do
+      before { config.service_secret = nil }
+
+      it "should raise ParameterError" do
+        expect{ config.encoded_keys }.to raise_error(RmsWebService::ParameterError, /service_secret/)
       end
     end
 
-    context 'set serviceSecret and licenseKey correctly' do
-      before :each do
-        RmsWebService.configuration do |c|
-          c.service_secret = 'dummy_service_secret'
-          c.license_key = 'dummy_license_key'
-        end
-      end
-  
-      it 'can set parameters properly' do
-        expect(config.service_secret).to eq 'dummy_service_secret'
-        expect(config.license_key).to eq 'dummy_license_key'
-      end
-  
-      it 'return encoded keys' do
-        expect(Base64.decode64(config.encoded_keys.gsub('ESA ', ''))).to eq 'dummy_service_secret:dummy_license_key'
+    context "without license_key" do
+      before { config.license_key = nil }
+
+      it "should raise ParameterError" do
+        expect{ config.encoded_keys }.to raise_error(RmsWebService::ParameterError, /license_key/)
       end
     end
   end

--- a/spec/rms_web_service/item/delete_spec.rb
+++ b/spec/rms_web_service/item/delete_spec.rb
@@ -6,12 +6,12 @@ describe RmsWebService::Item::Delete do
     let(:api) {RmsWebService::Item.delete({:item_url => 'test001'})}
 
     before :all do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end
     end
-  
+
     before :each do
       stub_request(:post, "https://api.rms.rakuten.co.jp/es/1.0/item/delete")
       .to_return(:status => 200, body: fixture('delete.xml'))

--- a/spec/rms_web_service/item/get_spec.rb
+++ b/spec/rms_web_service/item/get_spec.rb
@@ -6,7 +6,7 @@ describe RmsWebService::Item::Get do
     let(:api) {RmsWebService::Item.get(:item_url => 'test001')}
 
     before do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end

--- a/spec/rms_web_service/item/insert_spec.rb
+++ b/spec/rms_web_service/item/insert_spec.rb
@@ -10,12 +10,12 @@ describe RmsWebService::Item::Insert do
     })}
 
     before :all do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end
     end
-  
+
     before :each do
       stub_request(:post, "https://api.rms.rakuten.co.jp/es/1.0/item/insert")
       .to_return(:status => 200, body: fixture('insert.xml'))

--- a/spec/rms_web_service/item/items_update_spec.rb
+++ b/spec/rms_web_service/item/items_update_spec.rb
@@ -9,7 +9,7 @@ describe RmsWebService::Item::ItemsUpdate do
     ])}
 
     before do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end

--- a/spec/rms_web_service/item/search_spec.rb
+++ b/spec/rms_web_service/item/search_spec.rb
@@ -6,7 +6,7 @@ describe RmsWebService::Item::Search do
     let(:api) {RmsWebService::Item.search(:item_name => 'test001', :item_price_from => 1)}
 
     before do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end

--- a/spec/rms_web_service/item/update_spec.rb
+++ b/spec/rms_web_service/item/update_spec.rb
@@ -6,12 +6,12 @@ describe RmsWebService::Item::Update do
     let(:api) {RmsWebService::Item.update({:item_url => 'test001', :item_price => '10000'})}
 
     before :all do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end
     end
-  
+
     before :each do
       stub_request(:post, "https://api.rms.rakuten.co.jp/es/1.0/item/update")
       .to_return(:status => 200, body: fixture('update.xml'))

--- a/spec/rms_web_service/item_spec.rb
+++ b/spec/rms_web_service/item_spec.rb
@@ -4,7 +4,7 @@ require 'rms_web_service/item'
 describe RmsWebService::Item do
   describe '.connection' do
     before do
-      RmsWebService.configuration do |c|
+      RmsWebService.configure do |c|
         c.service_secret = 'dummy_service_secret'
         c.license_key = 'dummy_license_key'
       end

--- a/spec/rms_web_service_spec.rb
+++ b/spec/rms_web_service_spec.rb
@@ -1,1 +1,11 @@
 require 'spec_helper'
+
+describe RmsWebService do
+  describe '.configure' do
+  end
+
+  describe ".configuration" do
+    subject { described_class.configuration }
+    it { is_expected.to be_a(RmsWebService::Configuration) }
+  end
+end


### PR DESCRIPTION
`RmsWebService.configuration`という名詞のメソッドで設定を行うのが気持ち悪かったので、`RmsWebService.configure`に切り出しました。

それにともない、`RmsWebService.configuration`は`RmsWebService.configure`で設定した結果を保持する`RmsWebService::Configuration`クラスのインスタンスを返すだけになりました。

その他、上記変更に伴うSpecの修正が入っています。
